### PR TITLE
Create front-end for poker hand AI interpretation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,208 +3,817 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Póker leosztás lejátszó – RIROPO beágyazással</title>
-  <meta name="description" content="Póker hand history beillesztése és lejátszása a nyílt forrású RIROPO replayerrel." />
+  <title>Póker hand AI értelmező</title>
+  <meta name="description" content="Írd be szövegesen a póker szituációt, majd egy szimulált AI-hívás feldolgozza a stackméretet, pozíciót és a kiosztott lapot." />
   <style>
     :root {
-      --bg: #0b0f14;
-      --card: #121821;
-      --muted: #8aa0b1;
-      --text: #e7eef5;
-      --accent: #4cc9f0;
-      --accent-2: #80ed99;
-      --danger: #ff6b6b;
-      --shadow: 0 10px 30px rgba(0,0,0,.35);
-      --radius: 14px;
+      --bg: #060910;
+      --card: #0d1423;
+      --text: #f4f6fb;
+      --muted: #8f9bb3;
+      --accent: #6c63ff;
+      --accent-2: #5ef3c0;
+      --border: rgba(255, 255, 255, 0.08);
+      --shadow: 0 24px 80px rgba(5, 10, 20, 0.55);
+      --danger: #ff6b81;
     }
-    * { box-sizing: border-box; }
-    html, body { height: 100%; }
+
+    * {
+      box-sizing: border-box;
+    }
+
     body {
-      margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
-      background: linear-gradient( to bottom right, #0a0f14, #0e141c 60%, #0b1018 );
+      margin: 0;
+      font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+      background: radial-gradient(circle at top left, rgba(108, 99, 255, 0.22), transparent 50%),
+                  radial-gradient(circle at 80% 20%, rgba(94, 243, 192, 0.18), transparent 55%),
+                  var(--bg);
       color: var(--text);
-    }
-    .app { max-width: 1200px; margin: 24px auto; padding: 0 16px; }
-    header { display:flex; align-items:center; justify-content:space-between; margin-bottom: 18px; }
-    header h1 { font-size: clamp(20px, 2.6vw, 28px); margin:0; letter-spacing:.2px; }
-    header .badge { font-size: 12px; color: var(--muted); }
-
-    .grid { display:grid; grid-template-columns: 1fr 1.2fr; gap: 18px; }
-    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
-
-    .card { background: radial-gradient(1200px 500px at 10% -20%, rgba(76,201,240,.07), transparent 40%),
-                        radial-gradient(1200px 600px at 100% 0%, rgba(128,237,153,.06), transparent 45%),
-                        var(--card);
-            border: 1px solid rgba(255,255,255,.06);
-            border-radius: var(--radius); box-shadow: var(--shadow);
+      line-height: 1.6;
+      min-height: 100vh;
+      -webkit-font-smoothing: antialiased;
     }
 
-    .input-pane { padding: 18px; display:flex; flex-direction:column; gap:12px; }
-    label { font-size: 13px; color: var(--muted); }
-    textarea {
-      width: 100%; min-height: 260px; resize: vertical;
-      padding: 14px 14px 18px; border-radius: 12px; background: #0f1621; color: var(--text);
-      border: 1px solid rgba(255,255,255,.08); outline: none; line-height: 1.35;
-      box-shadow: inset 0 0 0 1px rgba(0,0,0,.3);
-    }
-    textarea::placeholder { color: #6d8596; }
-
-    .actions { display:flex; gap: 10px; flex-wrap: wrap; align-items:center; }
-    button {
-      appearance: none; border: none; cursor: pointer; padding: 12px 16px;
-      border-radius: 12px; font-weight: 600; letter-spacing:.2px;
-      background: linear-gradient(180deg, var(--accent), #2aa7cf);
-      color: #061018; box-shadow: 0 8px 20px rgba(76,201,240,.25), inset 0 -2px 6px rgba(0,0,0,.25);
-      transition: transform .06s ease, filter .2s ease;
-    }
-    button:hover { filter: brightness(1.06); }
-    button:active { transform: translateY(1px); }
-    .btn-secondary { background: linear-gradient(180deg, #98f5c2, #3dbf78); }
-    .btn-ghost { background: transparent; color: var(--muted); border:1px dashed rgba(255,255,255,.15); box-shadow:none; }
-
-    .hint { color: var(--muted); font-size: 12px; }
-
-    .player-pane { position: relative; padding: 12px; }
-    iframe {
-      width: 100%; height: min(70vh, 760px); border: 1px solid rgba(255,255,255,.08);
-      border-radius: 12px; background: #0a0f14; box-shadow: var(--shadow);
+    a {
+      color: var(--accent-2);
     }
 
-    .overlay { position: absolute; inset: 12px; display: none; align-items: center; justify-content:center; }
-    .overlay[aria-hidden="false"] { display:flex; }
-    .overlay .inner {
-      max-width: 640px; width: 100%; background: rgba(11,15,20,.9); backdrop-filter: blur(6px);
-      border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 18px;
-      box-shadow: var(--shadow); text-align: left; line-height:1.5;
+    .page {
+      padding: clamp(24px, 5vw, 48px);
     }
-    .overlay h3 { margin: 0 0 8px 0; font-size: 18px; }
-    .overlay p { margin: 6px 0; color: var(--muted); }
-    .overlay .close { margin-top: 12px; background: transparent; color: var(--text); border:1px solid rgba(255,255,255,.15); }
 
-    .toast { position: fixed; bottom: 20px; right: 20px; background: #0f1a25; border:1px solid rgba(255,255,255,.1);
-      color: var(--text); padding: 10px 12px; border-radius: 10px; display:none; }
-    .toast[aria-hidden="false"] { display:block; }
+    .hero {
+      max-width: 760px;
+      margin: 0 auto clamp(28px, 5vw, 40px);
+      text-align: center;
+    }
 
-    .error { color: var(--danger); font-size: 12px; display:none; }
-    .error[aria-hidden="false"] { display:block; }
-    .mini { font-size: 12px; color: var(--muted); }
-    footer { margin-top: 14px; color: var(--muted); font-size: 12px; text-align:center; }
-    a { color: var(--accent); text-decoration: none; }
-  </style>
-</head>
-<body>
-  <div class="app">
-    <header>
-      <h1>Leosztás lejátszó <span class="badge">— RIROPO beágyazás</span></h1>
-      <div class="mini">Nyílt forráskódú replayer: RIROPO</div>
-    </header>
+    .hero__eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 14px;
+      font-size: 12px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      background: rgba(255, 255, 255, 0.06);
+      color: var(--muted);
+      border-radius: 999px;
+      margin-bottom: 16px;
+    }
 
-    <main class="grid">
-      <!-- Bal oldal: kézi beviteli felület -->
-      <section class="card input-pane" aria-labelledby="hhlabel">
-        <label id="hhlabel" for="hh">Illeszd be ide a póker leosztásod (angol hand history, pl. PokerStars / GGPoker):</label>
-        <textarea id="hh" placeholder="Pl.: PokerStars Hand #1234567890:  Hold'em No Limit ($0.05/$0.10 USD) ..."></textarea>
-        <div class="actions">
-          <button id="playBtn" type="button" title="Vágólapra másolás és lejátszás">Lejátszás →</button>
-          <button id="demoBtn" type="button" class="btn-secondary" title="Demo leosztás betöltése">Demo betöltése</button>
-          <button id="clearBtn" type="button" class="btn-ghost" title="Mező ürítése">Törlés</button>
-        </div>
-        <div id="err" class="error" aria-hidden="true">Adj meg egy leosztást a lejátszáshoz.</div>
-        <p class="hint">Megjegyzés: a RIROPO jelenleg angol nyelvű hand history-t támogat (PokerStars, GGPoker). A gomb a szöveget a vágólapra másolja, majd az alábbi beágyazott lejátszót nyitja meg; ott egyszerűen <strong>Ctrl+V</strong> (Mac: <strong>⌘V</strong>) és kövesd a webhely útmutatását.</p>
-      </section>
+    .hero h1 {
+      margin: 0 0 12px;
+      font-size: clamp(30px, 6vw, 46px);
+      letter-spacing: -0.01em;
+    }
 
-      <!-- Jobb oldal: beágyazott RIROPO -->
-      <section class="card player-pane">
-        <iframe id="riropo" title="RIROPO – Online Poker Replayer" src="about:blank"
-                loading="lazy"
-                sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin"
-                referrerpolicy="no-referrer-when-downgrade"></iframe>
+    .hero p {
+      margin: 0 auto;
+      color: var(--muted);
+      font-size: clamp(15px, 2.4vw, 18px);
+      max-width: 640px;
+    }
 
-        <!-- Interaktív súgó overlay a beillesztéshez -->
-        <div id="overlay" class="overlay" aria-hidden="true" aria-live="polite">
-          <div class="inner">
-            <h3>A leosztás a vágólapra került ✅</h3>
-            <p>1) Kattints az alábbi lejátszó <em>ablakára</em> (RIROPO).</p>
-            <p>2) Nyomd meg: <strong>Ctrl+V</strong> (Mac: <strong>⌘V</strong>) a beillesztéshez.</p>
-            <p>3) Kövesd a megjelenő utasításokat a lejátszó felületén.</p>
-            <button class="close" type="button" id="closeOverlay">Értem</button>
-          </div>
-        </div>
-      </section>
-    </main>
+    .layout {
+      max-width: 1100px;
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: clamp(24px, 4vw, 36px);
+    }
 
-    <footer>
-      Ez a lap a <a href="https://replayer.winningpokerhud.com/" target="_blank" rel="noopener">RIROPO</a> beágyazott használatára épül. A RIROPO GPLv3 licenc alatt érhető el a <a href="https://github.com/vikcch/riropo" target="_blank" rel="noopener">GitHubon</a>.
-    </footer>
-
-    <div id="toast" class="toast" aria-hidden="true">Vágólapra másolva.</div>
-  </div>
-
-  <script>
-    // ——— Segédfüggvények ———
-    const $ = (sel) => document.querySelector(sel);
-    const show = (el) => el.setAttribute('aria-hidden', 'false');
-    const hide = (el) => el.setAttribute('aria-hidden', 'true');
-
-    async function copyToClipboard(text, textareaEl) {
-      try {
-        await navigator.clipboard.writeText(text);
-        return true;
-      } catch (err) {
-        // Fallback: klasszikus kijelölés + execCommand
-        try {
-          textareaEl.select();
-          document.execCommand('copy');
-          return true;
-        } catch (e) {
-          return false;
-        }
+    @media (max-width: 960px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+      .hero {
+        text-align: left;
       }
     }
 
-    function toast(msg, ms = 1600) {
-      const t = $('#toast');
-      t.textContent = msg; show(t);
-      setTimeout(() => hide(t), ms);
+    .card {
+      position: relative;
+      background: linear-gradient(145deg, rgba(255, 255, 255, 0.08), transparent 60%), var(--card);
+      border: 1px solid var(--border);
+      border-radius: clamp(20px, 4vw, 28px);
+      padding: clamp(22px, 4vw, 32px);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      backdrop-filter: blur(14px);
     }
 
-    // ——— Eseménykezelők ———
-    const playBtn = $('#playBtn');
-    const demoBtn = $('#demoBtn');
-    const clearBtn = $('#clearBtn');
-    const err = $('#err');
-    const overlay = $('#overlay');
-    const closeOverlay = $('#closeOverlay');
-    const iframe = $('#riropo');
+    .card::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      background: radial-gradient(600px 300px at 0% 0%, rgba(94, 243, 192, 0.12), transparent 65%);
+      mix-blend-mode: screen;
+    }
 
-    playBtn.addEventListener('click', async () => {
-      const ta = $('#hh');
-      const text = ta.value.trim();
-      if (!text) { show(err); ta.focus(); return; }
-      hide(err);
-      const ok = await copyToClipboard(text, ta);
-      if (ok) { toast('Vágólapra másolva.'); }
-      // Betöltjük a RIROPO felületet az iframe-be
-      iframe.src = 'https://replayer.winningpokerhud.com/index.php';
-      // Súgófelület megjelenítése
-      show(overlay);
-    });
+    .card.card--output::after {
+      background: radial-gradient(600px 320px at 100% 0%, rgba(108, 99, 255, 0.14), transparent 68%);
+    }
 
-    demoBtn.addEventListener('click', () => {
-      hide(err);
-      // Példaképp állítunk egy minimális, fiktív hand history-t a szövegmezőbe
-      $('#hh').value = `PokerStars Hand #9999999999:  Hold'em No Limit ($0.01/$0.02 USD) - 2025/09/08 18:30:00 ET\nTable 'Alpha' 6-max Seat #3 is the button\nSeat 1: Hero ($2.00 in chips)\nSeat 2: Villain ($2.10 in chips)\nHero: posts small blind $0.01\nVillain: posts big blind $0.02\n*** HOLE CARDS ***\nDealt to Hero [Ah Kh]\nHero: raises $0.04 to $0.05\nVillain: calls $0.03\n*** FLOP *** [As 7d 2c]\nVillain: checks\nHero: bets $0.05\nVillain: calls $0.05\n*** TURN *** [As 7d 2c] [Td]\nVillain: checks\nHero: bets $0.12\nVillain: calls $0.12\n*** RIVER *** [As 7d 2c Td] [2h]\nVillain: checks\nHero: bets $0.28\nVillain: calls $0.28\n*** SHOW DOWN ***\nHero: shows [Ah Kh] (two pair, Aces and Twos)\nVillain: shows [Ad 9d] (two pair, Aces and Twos – lower kicker)\nHero collected $1.00 from pot`; // csak illusztráció
-      // RIROPO demo kéz betöltése iframe-be
-      iframe.src = 'https://replayer.winningpokerhud.com/index.php?id=1080';
-      hide(overlay);
-    });
+    .card > * {
+      position: relative;
+      z-index: 1;
+    }
 
-    clearBtn.addEventListener('click', () => { $('#hh').value = ''; hide(err); $('#hh').focus(); });
-    closeOverlay.addEventListener('click', () => hide(overlay));
+    form {
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+    }
 
-    // Tipp: ha saját szerveren hostolod a RIROPO-t, elég a domain cseréje:
-    // iframe.src = 'https://sajat-domen.hu/riropo/index.php';
-    // — és máris offline/önálló a megoldás.
+    label {
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+
+    textarea {
+      min-height: 220px;
+      border-radius: 20px;
+      border: 1px solid rgba(255, 255, 255, 0.09);
+      background: rgba(7, 11, 20, 0.86);
+      color: inherit;
+      font: inherit;
+      padding: 18px 20px;
+      line-height: 1.5;
+      resize: vertical;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    textarea:focus {
+      outline: none;
+      border-color: rgba(108, 99, 255, 0.8);
+      box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.25);
+    }
+
+    textarea::placeholder {
+      color: rgba(255, 255, 255, 0.35);
+    }
+
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+
+    .btn {
+      appearance: none;
+      border: none;
+      border-radius: 999px;
+      padding: 12px 24px;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.2s ease, filter 0.2s ease;
+    }
+
+    .btn:focus-visible {
+      outline: 3px solid rgba(108, 99, 255, 0.35);
+      outline-offset: 3px;
+    }
+
+    .btn--primary {
+      background: linear-gradient(135deg, var(--accent), var(--accent-2));
+      color: #04070f;
+      box-shadow: 0 14px 32px rgba(108, 99, 255, 0.45);
+    }
+
+    .btn--primary:hover {
+      transform: translateY(-2px);
+      filter: brightness(1.05);
+    }
+
+    .btn--ghost {
+      background: transparent;
+      color: var(--muted);
+      border: 1px dashed rgba(255, 255, 255, 0.26);
+    }
+
+    .btn--ghost:hover {
+      border-color: rgba(255, 255, 255, 0.45);
+      color: var(--text);
+    }
+
+    .hint {
+      font-size: 0.9rem;
+      color: var(--muted);
+      margin-top: -8px;
+    }
+
+    .error {
+      font-size: 0.9rem;
+      color: var(--danger);
+      margin-top: -4px;
+    }
+
+    .state {
+      display: none;
+    }
+
+    .state.is-active {
+      display: block;
+      animation: fade 0.35s ease;
+    }
+
+    .state h2 {
+      margin-top: 0;
+      margin-bottom: 10px;
+      font-size: clamp(20px, 4vw, 26px);
+    }
+
+    .state p {
+      color: var(--muted);
+      margin: 0;
+    }
+
+    .spinner {
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      border: 4px solid rgba(255, 255, 255, 0.14);
+      border-top-color: var(--accent);
+      animation: spin 1s linear infinite;
+      margin-bottom: 18px;
+    }
+
+    .result-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 18px;
+      margin-top: 24px;
+    }
+
+    .result-card {
+      background: rgba(255, 255, 255, 0.05);
+      border-radius: 18px;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      padding: 18px;
+      min-height: 150px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .result-card h3 {
+      margin: 0;
+      font-size: 0.95rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: rgba(255, 255, 255, 0.65);
+    }
+
+    .result-value {
+      font-size: 1.4rem;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .result-source {
+      font-size: 0.85rem;
+      color: var(--muted);
+      line-height: 1.45;
+    }
+
+    .result-source mark {
+      background: rgba(108, 99, 255, 0.22);
+      color: inherit;
+      padding: 0.08em 0.4em;
+      border-radius: 8px;
+    }
+
+    .result-label {
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-size: 0.7rem;
+      color: rgba(255, 255, 255, 0.6);
+      margin-right: 6px;
+    }
+
+    .playing-card {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 48px;
+      height: 64px;
+      border-radius: 12px;
+      font-weight: 700;
+      font-size: 1.4rem;
+      background: #f9fbff;
+      box-shadow: 0 10px 26px rgba(4, 7, 15, 0.35);
+      font-feature-settings: "lnum" 1;
+    }
+
+    .playing-card--spade,
+    .playing-card--club {
+      color: #141827;
+    }
+
+    .playing-card--heart,
+    .playing-card--diamond {
+      color: #c4315f;
+      background: #fff2f6;
+    }
+
+    .hand-text {
+      font-size: 1.2rem;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      padding: 8px 12px;
+      border-radius: 12px;
+      background: rgba(108, 99, 255, 0.18);
+    }
+
+    .meta {
+      font-size: 0.85rem;
+      color: var(--muted);
+      margin-top: 8px;
+    }
+
+    .notes {
+      margin-top: 24px;
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+      padding-top: 16px;
+      font-size: 0.95rem;
+      color: var(--muted);
+    }
+
+    .notes h3 {
+      margin: 0 0 8px;
+      font-size: 0.95rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.65);
+    }
+
+    .notes ul {
+      margin: 10px 0 0;
+      padding-left: 18px;
+      display: grid;
+      gap: 8px;
+    }
+
+    .notes li {
+      list-style: disc;
+    }
+
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+
+    @keyframes fade {
+      from {
+        opacity: 0;
+        transform: translateY(6px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    @media (max-width: 620px) {
+      .card {
+        border-radius: 20px;
+      }
+      .playing-card {
+        width: 42px;
+        height: 56px;
+        font-size: 1.2rem;
+      }
+      .result-value {
+        font-size: 1.2rem;
+      }
+      .controls {
+        flex-direction: column;
+        align-items: stretch;
+      }
+      .controls .btn {
+        width: 100%;
+        justify-content: center;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header class="hero">
+      <div class="hero__eyebrow">AI segéd &middot; póker szituáció elemzése</div>
+      <h1>Írd le a leosztást, az AI segít értelmezni</h1>
+      <p>Röviden fogalmazd meg a póker szituációdat. A bevitel gomb megnyomása után egy szimulált AI-hívás felderíti a stackméretet, a pozíciót és a kiosztott lapot.</p>
+    </header>
+
+    <main class="layout">
+      <section class="card card--input" aria-labelledby="description-label">
+        <form id="handForm">
+          <div>
+            <label id="description-label" for="handInput">Leírás</label>
+            <textarea id="handInput" name="hand" placeholder="Pl.: 20bb deep ülök a BU-n, előttem mindenki dob, és Ah Kh-t kapok." spellcheck="false" required></textarea>
+          </div>
+
+          <div class="controls">
+            <button type="submit" class="btn btn--primary">AI elemzés indítása</button>
+            <button type="button" id="clearBtn" class="btn btn--ghost">Törlés</button>
+          </div>
+
+          <p class="hint">A háttérben futó hívás jelenleg demó jellegű. Valós AI API-hoz elég a <code>simulateAiCall</code> függvényt lecserélni.</p>
+          <p id="errorMsg" class="error" role="alert" hidden>Kérlek, írd le röviden a szituációt.</p>
+        </form>
+      </section>
+
+      <section class="card card--output" aria-live="polite">
+        <div class="state state--idle is-active" data-state="idle">
+          <h2>Eredmények itt jelennek meg</h2>
+          <p>Írd be a hand történetét bal oldalt, majd indítsd el az AI elemzést.</p>
+        </div>
+
+        <div class="state state--loading" data-state="loading" role="status">
+          <div class="spinner" aria-hidden="true"></div>
+          <p>AI hívás folyamatban...</p>
+        </div>
+
+        <div class="state state--result" data-state="result">
+          <h2>AI által felismert adatok</h2>
+          <p id="analysisMeta" class="meta"></p>
+
+          <div class="result-grid">
+            <article class="result-card">
+              <h3>Stackméret</h3>
+              <div id="stackValue" class="result-value">-</div>
+              <p id="stackSource" class="result-source"></p>
+            </article>
+
+            <article class="result-card">
+              <h3>Pozíció</h3>
+              <div id="positionValue" class="result-value">-</div>
+              <p id="positionSource" class="result-source"></p>
+            </article>
+
+            <article class="result-card">
+              <h3>Lap</h3>
+              <div id="handValue" class="result-value">-</div>
+              <p id="handSource" class="result-source"></p>
+            </article>
+          </div>
+
+          <div id="notes" class="notes" hidden></div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script>
+    (function () {
+      const form = document.getElementById('handForm');
+      const input = document.getElementById('handInput');
+      const clearBtn = document.getElementById('clearBtn');
+      const errorMsg = document.getElementById('errorMsg');
+
+      const states = document.querySelectorAll('[data-state]');
+      const stackValue = document.getElementById('stackValue');
+      const stackSource = document.getElementById('stackSource');
+      const positionValue = document.getElementById('positionValue');
+      const positionSource = document.getElementById('positionSource');
+      const handValue = document.getElementById('handValue');
+      const handSource = document.getElementById('handSource');
+      const notesEl = document.getElementById('notes');
+      const metaEl = document.getElementById('analysisMeta');
+
+      function setState(activeName) {
+        states.forEach((el) => {
+          if (el.dataset.state === activeName) {
+            el.classList.add('is-active');
+          } else {
+            el.classList.remove('is-active');
+          }
+        });
+      }
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const description = input.value.trim();
+
+        if (!description) {
+          errorMsg.hidden = false;
+          setState('idle');
+          input.focus();
+          return;
+        }
+
+        errorMsg.hidden = true;
+        setState('loading');
+
+        try {
+          const result = await simulateAiCall(description);
+          displayResult(result);
+        } catch (err) {
+          console.error('AI hívás sikertelen', err);
+          setState('result');
+          metaEl.textContent = '';
+          stackValue.textContent = 'Hiba';
+          stackSource.textContent = 'Nem sikerült feldolgozni a kérést.';
+          positionValue.textContent = '-';
+          positionSource.textContent = '';
+          handValue.textContent = '-';
+          handSource.textContent = '';
+          notesEl.hidden = false;
+          notesEl.innerHTML = '<h3>Megjegyzések</h3><ul><li>Hálózati vagy feldolgozási hiba történt. Próbáld meg később újra.</li></ul>';
+        }
+      });
+
+      clearBtn.addEventListener('click', () => {
+        input.value = '';
+        input.focus();
+        errorMsg.hidden = true;
+        setState('idle');
+        stackValue.textContent = '-';
+        positionValue.textContent = '-';
+        handValue.textContent = '-';
+        stackSource.textContent = '';
+        positionSource.textContent = '';
+        handSource.textContent = '';
+        metaEl.textContent = '';
+        notesEl.hidden = true;
+        notesEl.innerHTML = '';
+      });
+
+      function simulateAiCall(description) {
+        const start = typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now();
+        return new Promise((resolve) => {
+          const delay = 850 + Math.random() * 600;
+          setTimeout(() => {
+            const stack = detectStack(description);
+            const position = detectPosition(description);
+            const hand = detectHand(description);
+            const end = typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now();
+            resolve({
+              stack,
+              position,
+              hand,
+              latency: Math.round(end - start),
+            });
+          }, delay);
+        });
+      }
+
+      function detectStack(text) {
+        const patterns = [
+          /(stack(?:méret|size)?\s*[:\-]?\s*)(\d+(?:[.,]\d+)?)(\s*)(bb|big\s*blinds?|vak)/i,
+          /(\d+(?:[.,]\d+)?)(\s*)(bb)(?=\b|\s|\.|,)/i,
+          /(\d+(?:[.,]\d+)?)(\s*)(bb)(?=\s*deep)/i,
+          /(\d+(?:[.,]\d+)?)(\s*)(?:big\s*blinds?)/i,
+        ];
+
+        for (const pattern of patterns) {
+          const match = pattern.exec(text);
+          if (match) {
+            const numeric = normaliseNumber(match[2] || match[1]);
+            const value = numeric ? `${numeric} bb` : `${match[2] || match[0]}`;
+            return {
+              found: true,
+              value,
+              snippet: match[0].trim(),
+              explanation: `A „${match[0].trim()}” részlet alapján lett meghatározva a stackméret.`,
+            };
+          }
+        }
+
+        return {
+          found: false,
+          suggestion: 'Adj meg például ilyen formát: „stack 20bb”, „25 big blind”, vagy „20bb deep”.',
+        };
+      }
+
+      function detectPosition(text) {
+        const candidates = [
+          { regex: /\b(BTN|BUTTON|BU)\b/i, short: 'BU', long: 'Button' },
+          { regex: /\b(CUT[\s\-]?OFF|CO)\b/i, short: 'CO', long: 'Cutoff' },
+          { regex: /\b(HI\s?JACK|HJ)\b/i, short: 'HJ', long: 'Hijack' },
+          { regex: /\b(MIDDLE\s?POSITION|MP)\b/i, short: 'MP', long: 'Middle Position' },
+          { regex: /\b(LOJACK|LJ)\b/i, short: 'LJ', long: 'Lojack' },
+          { regex: /\b(UTG\+?2)\b/i, short: 'UTG+2', long: 'Under the Gun +2' },
+          { regex: /\b(UTG\+?1|UTG1)\b/i, short: 'UTG+1', long: 'Under the Gun +1' },
+          { regex: /\b(UTG)\b/i, short: 'UTG', long: 'Under the Gun' },
+          { regex: /\b(SMALL\s*BLIND|SB)\b/i, short: 'SB', long: 'Small Blind' },
+          { regex: /\b(BIG\s*BLIND|BB)\b/i, short: 'BB', long: 'Big Blind' },
+        ];
+
+        for (const item of candidates) {
+          const match = item.regex.exec(text);
+          if (match) {
+            return {
+              found: true,
+              value: `${item.short} (${item.long})`,
+              snippet: match[0].trim(),
+              explanation: `A pozíciót a „${match[0].trim()}” kifejezés alapján állapítottuk meg.`,
+            };
+          }
+        }
+
+        const hungarianPatterns = [
+          { regex: /gombon|buttonön|buttonon/i, short: 'BU', long: 'Button' },
+          { regex: /cutoffban/i, short: 'CO', long: 'Cutoff' },
+          { regex: /hijackben/i, short: 'HJ', long: 'Hijack' },
+          { regex: /kisvakon/i, short: 'SB', long: 'Small Blind' },
+          { regex: /nagybakon/i, short: 'BB', long: 'Big Blind' },
+        ];
+
+        for (const item of hungarianPatterns) {
+          const match = item.regex.exec(text);
+          if (match) {
+            return {
+              found: true,
+              value: `${item.short} (${item.long})`,
+              snippet: match[0].trim(),
+              explanation: `A magyar megnevezés („${match[0].trim()}”) alapján azonosítottuk a pozíciót.`,
+            };
+          }
+        }
+
+        return {
+          found: false,
+          suggestion: 'Nevezd meg a pozíciót (pl. „BU”, „CO”, „kisvakban”, „UTG”), hogy az AI felismerje.',
+        };
+      }
+
+      function detectHand(text) {
+        const cardRegex = /(10|[2-9TJQKA])([shdcSHDC♠♥♦♣])/g;
+        const cards = [];
+        let match;
+        while ((match = cardRegex.exec(text)) !== null) {
+          const rank = normaliseRank(match[1]);
+          const suitInfo = suitFromChar(match[2]);
+          if (!rank || !suitInfo) {
+            continue;
+          }
+          cards.push({
+            rank,
+            suitSymbol: suitInfo.symbol,
+            suitClass: suitInfo.className,
+            suitName: suitInfo.name,
+            raw: match[0],
+            human: `${rankToName(rank)} ${suitInfo.name}`,
+          });
+          if (cards.length === 2) {
+            break;
+          }
+        }
+
+        if (cards.length >= 2) {
+          return {
+            found: true,
+            display: cards.map(renderCard).join(' '),
+            snippet: cards.map((card) => card.raw).join(' '),
+            explanation: `A leírás tartalmazta a ${cards[0].human.toLowerCase()} és a ${cards[1].human.toLowerCase()} lapokat.`,
+          };
+        }
+
+        const comboRegex = /\b([2-9TJQKA]{2})([sSoO])\b/;
+        const comboMatch = comboRegex.exec(text);
+        if (comboMatch) {
+          const ranks = comboMatch[1].toUpperCase();
+          const suitedChar = comboMatch[2].toLowerCase();
+          const typeLabel = suitedChar === 's' ? 'azonos színű (suited)' : 'különböző színű (offsuit)';
+          const rankOne = ranks[0];
+          const rankTwo = ranks[1];
+          return {
+            found: true,
+            display: `<span class="hand-text">${escapeHtml(ranks + suitedChar)}</span>`,
+            snippet: comboMatch[0],
+            explanation: `${rankToName(rankOne)}-${rankToName(rankTwo)} kombinációt jelöltél meg, ${typeLabel}.`,
+          };
+        }
+
+        return {
+          found: false,
+          suggestion: 'Add meg a lapot például így: „Ah Kh”, „Qs Jd” vagy rövidítve „AKs”.',
+        };
+      }
+
+      function renderCard(card) {
+        const label = `${rankToName(card.rank)} ${card.suitName}`;
+        return `<span class="playing-card playing-card--${card.suitClass}" aria-label="${escapeHtml(label)}">${card.rank}${card.suitSymbol}</span>`;
+      }
+
+      function normaliseNumber(value) {
+        if (!value) return null;
+        const prepared = value.replace(',', '.');
+        const numeric = Number.parseFloat(prepared);
+        if (Number.isFinite(numeric)) {
+          return Number.isInteger(numeric) ? String(numeric) : numeric.toFixed(1);
+        }
+        return null;
+      }
+
+      function normaliseRank(rank) {
+        if (!rank) return null;
+        const upper = rank.toUpperCase();
+        if (upper === '10') {
+          return 'T';
+        }
+        return upper;
+      }
+
+      function rankToName(rank) {
+        const names = {
+          A: 'Ász',
+          K: 'Király',
+          Q: 'Dáma',
+          J: 'Bubi',
+          T: 'Tíz',
+          '9': 'Kilenc',
+          '8': 'Nyolc',
+          '7': 'Hét',
+          '6': 'Hat',
+          '5': 'Öt',
+          '4': 'Négy',
+          '3': 'Három',
+          '2': 'Kettő',
+        };
+        return names[rank] || rank;
+      }
+
+      function suitFromChar(char) {
+        const map = {
+          s: { symbol: '♠', className: 'spade', name: 'pikk' },
+          h: { symbol: '♥', className: 'heart', name: 'kőr' },
+          d: { symbol: '♦', className: 'diamond', name: 'káró' },
+          c: { symbol: '♣', className: 'club', name: 'treff' },
+          '♠': { symbol: '♠', className: 'spade', name: 'pikk' },
+          '♥': { symbol: '♥', className: 'heart', name: 'kőr' },
+          '♦': { symbol: '♦', className: 'diamond', name: 'káró' },
+          '♣': { symbol: '♣', className: 'club', name: 'treff' },
+        };
+        const key = char.toLowerCase();
+        return map[key] || map[char] || null;
+      }
+
+      function escapeHtml(str) {
+        return String(str)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;');
+      }
+
+      function displayResult(data) {
+        setState('result');
+
+        const notes = [
+          'A jelenlegi feldolgozás szabályalapú demó. Valós AI API bekötéséhez cseréld le a <code>simulateAiCall</code> függvényt egy <code>fetch</code> hívásra.',
+        ];
+
+        if (data.stack.found) {
+          stackValue.textContent = data.stack.value;
+          stackSource.innerHTML = `<span class="result-label">Felismert részlet:</span> <mark>${escapeHtml(data.stack.snippet)}</mark><br>${escapeHtml(data.stack.explanation)}`;
+        } else {
+          stackValue.textContent = 'Nem egyértelmű';
+          stackSource.textContent = data.stack.suggestion;
+          notes.push('A stackméret felismeréséhez érdemes megadni a „bb” egységet (pl. 20bb).');
+        }
+
+        if (data.position.found) {
+          positionValue.textContent = data.position.value;
+          positionSource.innerHTML = `<span class="result-label">Felismert részlet:</span> <mark>${escapeHtml(data.position.snippet)}</mark><br>${escapeHtml(data.position.explanation)}`;
+        } else {
+          positionValue.textContent = 'Nem egyértelmű';
+          positionSource.textContent = data.position.suggestion;
+        }
+
+        if (data.hand.found) {
+          handValue.innerHTML = data.hand.display;
+          handSource.innerHTML = `<span class="result-label">Felismert jelölés:</span> <mark>${escapeHtml(data.hand.snippet)}</mark><br>${escapeHtml(data.hand.explanation)}`;
+        } else {
+          handValue.textContent = 'Nem egyértelmű';
+          handSource.textContent = data.hand.suggestion;
+          notes.push('A lap felismeréséhez használj standard jelölést: pl. Ah Kh vagy AKs.');
+        }
+
+        const seconds = (data.latency / 1000).toFixed(1);
+        metaEl.textContent = `Szimulált AI válaszidő: ${seconds} másodperc (${data.latency} ms).`;
+
+        if (notes.length) {
+          notesEl.hidden = false;
+          notesEl.innerHTML = `<h3>Megjegyzések</h3><ul>${notes
+            .map((note) => `<li>${note}</li>`)
+            .join('')}</ul>`;
+        } else {
+          notesEl.hidden = true;
+          notesEl.innerHTML = '';
+        }
+      }
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the previous RIROPO embed page with an AI-assisted poker hand interpretation interface
- add refreshed styling for the description form, result cards, and state transitions
- implement a simulated AI call that parses stack size, position, and dealt hand from the user's text input

## Testing
- no automated tests were run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68c86692b8a08333b8d35827f4ad155a